### PR TITLE
Resolve BeautifulSoup Parser Warning and Unhandled Exception

### DIFF
--- a/podscrape/driver.py
+++ b/podscrape/driver.py
@@ -1,6 +1,7 @@
 from models import Url
 import re
 
+
 class Driver(object):
     """
     Handles the traversal strategy of scraping the Podcast directory.
@@ -33,7 +34,7 @@ class Driver(object):
         self.letters = scraper.get_letter_urls()
         self.pages = scraper.get_page_urls()
 
-        #Collect each of the current selected Tags
+        # Collect each of the current selected Tags
         self.current_subgenre = scraper.get_currently_selected_subgenre()
         self.current_genre = scraper.get_currently_selected_genre()
         self.current_letter = scraper.get_currently_selected_letter()

--- a/podscrape/fetcher.py
+++ b/podscrape/fetcher.py
@@ -2,6 +2,7 @@ import requests
 from podscrape.scraper import Scraper
 from podscrape import lookup
 
+
 class Fetcher(object):
     """
     Handles http requests for outside data
@@ -39,5 +40,7 @@ class Fetcher(object):
         """
         podcasts = []
         for url in url_list:
-            podcasts.append(self.lookup(url))
+            podcast = self.lookup(url)
+            if podcast is not None:
+                podcasts.append(podcast)
         return podcasts

--- a/podscrape/lookup.py
+++ b/podscrape/lookup.py
@@ -6,6 +6,7 @@ import json
 import re
 from podscrape.models import Podcast
 
+
 def unwrap_json(json_text):
     """
     Extract first result from Lookup json response
@@ -26,14 +27,19 @@ def unwrap_json(json_text):
         single_json = json.dumps(single_result)
     return single_json
 
+
 def podcast_from_json(json_text):
     """Return Podcast with info from json_text"""
-    text = unwrap_json(json_text)
-    json_dict = json.loads(text)
-    itunes_id = json_dict[u'collectionId']
-    name = json_dict[u'collectionName']
-    feed_url = json_dict[u'feedUrl']
+    try:
+        text = unwrap_json(json_text)
+        json_dict = json.loads(text)
+        itunes_id = json_dict[u'collectionId']
+        name = json_dict[u'collectionName']
+        feed_url = json_dict[u'feedUrl']
+    except KeyError:
+        return None
     return Podcast(itunes_id, name, feed_url)
+
 
 def itunes_id_from_url(url):
     """Return id number from itunes podcast url"""

--- a/podscrape/models.py
+++ b/podscrape/models.py
@@ -10,6 +10,7 @@ class Url(object):
     def __eq__(self, other):
         return self.__dict__ == other.__dict__
 
+
 class Podcast(object):
     """
     Holds the useful components of a Podcast entry

--- a/podscrape/output.py
+++ b/podscrape/output.py
@@ -1,6 +1,7 @@
 import codecs
 from podscrape.models import Url, Podcast
 
+
 class FileOutput(object):
     """
     Writes info passed in to file. Handles two different data streams.
@@ -63,6 +64,7 @@ class FileOutput(object):
             f.write(line)
 
         f.close()
+
 
 class NullOutput(object):
     """

--- a/podscrape/scraper.py
+++ b/podscrape/scraper.py
@@ -1,6 +1,7 @@
 from bs4 import BeautifulSoup
 from models import Url
 
+
 class Scraper(object):
     """
     Extracts elements of an iTunes Podcast directory page.
@@ -10,7 +11,7 @@ class Scraper(object):
     """
 
     def __init__(self, text):
-        self.soup = BeautifulSoup(text)
+        self.soup = BeautifulSoup(text, 'lxml')
 
     def get_itunes_podcast_urls(self):
         """Return a list of all podcast urls on this page."""
@@ -204,6 +205,7 @@ class Scraper(object):
             if selected_tag:
                 selected = Url(selected_tag.get('href'), selected_tag.string)
         return selected
+
 
 def make_soup_from_file(filename):
     """Return BeautifulSoup of the text in filename"""

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ beautifulsoup4
 nose
 requests
 wsgiref
+lxml


### PR DESCRIPTION
## Purpose
This pull request fixes a warning thrown by BeautifulSoup and an error condition that causes the program to crash due to an unhandled exception. 

## Approach
When ran, the program would display the following error message: 
```
UserWarning: No parser was explicitly specified, so I'm using the best
available HTML parser for this system ("html.parser"). This usually isn't a
problem, but if you run this code on another system, or in a different
virtual environment, it may use a different parser and behave differently.

To get rid of this warning, change this:

 BeautifulSoup([your markup])

to this:

 BeautifulSoup([your markup], "html.parser")
```

BeautifulSoup recommends using lxml as a faster parser, so I've added lxml to the requirements file and to the BeautifulSoup call.

----

Regarding the unhandled exception, it appears that some items caught by the crawler identify as podcasts, but do no have feedURLs, which causes the program to throw a `KeyError` exception, which was previously unhandled causing the application to crash.

I've wrapped the JSON loading in a try/except to catch the exception and have the function return `None` in the case that the JSON doesn't include a feedURL. Of course, this means that the function calling `podcast_from_json()` needed to be able to deal with `None` being returned, so I modified that function to only add a Podcast object to the list if it was not `None`.